### PR TITLE
Support Java-style escape sequences

### DIFF
--- a/examples/StringEscape.sf
+++ b/examples/StringEscape.sf
@@ -1,0 +1,14 @@
+let print (s: String) = {
+  java.lang.System.out.print(s);
+  "\"Escaped string tests done!\""
+};
+
+{
+  print("\"Hello, world\"\n");
+  print("中文測試\n");
+  print(String.valueOf('\'').concat("Single quotation marks'").concat(String.valueOf('\n')));
+  print("Unicode test: \u2318\n");
+  print("Hex test: \u003cHex\u003e\n");
+  print("Oct test: \173Oct\175\n");
+  print("------\n")
+}


### PR DESCRIPTION
Support [Java-style escape sequences](http://docs.oracle.com/javase/tutorial/java/data/characters.html) (e.g. `\uDDDD` for Unicode character) by referring to the lexer of [Language.Java](https://hackage.haskell.org/package/language-java) package v0.2.7. Add an example `examples/StringEscape.sf` for using escape characters. This pull request is intended to solve Issue #72.
