### PR TITLE
Decouple interface from implementation for Simplify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test : dependencies runtime
 .PHONY : test2
 test2 : dependencies runtime
 	make parsers
-	runhaskell -i$(srcdir) $(srcdir)/FileLoad.hs
+	runhaskell -i$(srcdir):lib/simplify $(srcdir)/FileLoad.hs
 
 .PHONY : dependencies
 dependencies : 

--- a/fcore.cabal
+++ b/fcore.cabal
@@ -35,7 +35,7 @@ library
                       , transformers == 0.3.*
   build-tools:          alex == 3.1.*,
                         happy == 1.19.*
-  hs-source-dirs:       lib
+  hs-source-dirs:       lib,lib/simplify
   exposed-modules:      ApplyTransCFJava
                         BaseTransCFJava
                         BenchGenCF2J
@@ -76,6 +76,7 @@ library
                         TestInh
                         Translations
                         TypeCheck
+  other-modules:        SimplifyImpl
   if flag(Z3)
                         exposed-modules: SymbolicEvaluator, Z3Backend
                         build-depends: z3 >= 0.3.2

--- a/lib/SystemFI.hs
+++ b/lib/SystemFI.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances, RankNTypes #-}
 {-# OPTIONS_GHC -Wall #-}
 {- |
 Module      :  SystemFI
@@ -14,6 +14,7 @@ Portability :  portable
 module SystemFI
   ( Type(..)
   , Expr(..)
+  , FExp(..)
   , Constructor(..)
   , Alt(..)
   , DataBind(..)
@@ -109,6 +110,8 @@ data Expr t e
   | Data Src.RecFlag [DataBind t] (Expr t e)
   | Constr (Constructor t) [Expr t e]
   | Case (Expr t e) [Alt t e]
+   
+newtype FExp = HideF { revealF :: forall t e. Expr t e }
 
 data Alt t e = ConstrAlt (Constructor t) [Src.ReaderId] ([e] -> Expr t e)
             -- | Default (Expr t e)

--- a/lib/Translations.hs
+++ b/lib/Translations.hs
@@ -32,7 +32,7 @@ import           BenchGenCF2J
 import           BenchGenStack
 import           ClosureF
 import qualified Core
-import qualified SystemFI
+import qualified SystemFI as FI
 import           Desugar (desugar)
 import           Inheritance
 import           Inliner
@@ -41,7 +41,7 @@ import           MonadLib
 import           Parser
 import           PartialEvaluator
 import           PrettyUtils
-import           Simplify (simplify, FExp(..))
+import           Simplify (simplify)
 import           StackTransCFJava
 import           TypeCheck (typeCheck)
 -- import           UnboxTransCFJava
@@ -168,8 +168,8 @@ sf2java optInline optDump compilation className src =
            Right (_, tcheckedSrc)   ->
              do when (optDump == DumpTChecked) $ print tcheckedSrc
                 let core = desugar tcheckedSrc
-                when (optDump == DumpCore) $ print (SystemFI.prettyExpr core)
-                let simpleCore = simplify (HideF core)
+                when (optDump == DumpCore) $ print (FI.prettyExpr core)
+                let simpleCore = simplify (FI.HideF core)
                 let rewrittencore = rewriteAndEval (Hide simpleCore)
                 let recurNumOfCore = if optInline then recurNum rewrittencore else 0 -- inline
                 let inlineNum = if recurNumOfCore > 2 then 0 else recurNumOfCore

--- a/lib/simplify/Simplify.hs
+++ b/lib/simplify/Simplify.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE TypeOperators, FlexibleInstances, MultiParamTypeClasses, RankNTypes #-}
+{-# OPTIONS_GHC -Wall #-}
+{- |
+Module      :  Simplify
+Description :  The simplifier turns SystemFI into Core.
+Copyright   :  (c) 2014—2015 The F2J Project Developers (given in AUTHORS.txt)
+License     :  BSD3
+
+Maintainer  :  Zhiyuan Shi <zhiyuan.shi@gmail.com>, Haoyuan Zhang <zhanghaoyuan00@gmail.com>
+Stability   :  experimental
+Portability :  portable
+
+The simplifier translates System F with intersection types to vanilla System F.
+-}
+
+module Simplify
+  ( simplify
+  , simplify'
+  ) where
+
+import qualified SimplifyImpl         as Impl
+
+import Core
+import qualified SystemFI             as FI
+
+import Unsafe.Coerce (unsafeCoerce)
+
+simplify :: FI.FExp -> Expr t e
+simplify = Impl.simplify
+
+simplify' :: FI.Expr t e -> Expr t e
+simplify' = Impl.dedeBruE 0 [] 0 [] . Impl.transExpr 0 0 . unsafeCoerce

--- a/lib/simplify/SimplifyImpl.hs
+++ b/lib/simplify/SimplifyImpl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeOperators, FlexibleInstances, MultiParamTypeClasses, RankNTypes #-}
+{-# LANGUAGE TypeOperators, FlexibleInstances, MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -Wall #-}
 {- |
 Module      :  Simplify
@@ -13,10 +13,9 @@ Portability :  portable
 The simplifier translates System F with intersection types to vanilla System F.
 -}
 
-module Simplify
+module SimplifyImpl
   ( simplify
   , simplify'
-  , FExp(..)
   , infer
   , transExpr
   , transType
@@ -38,13 +37,11 @@ import Data.Maybe    (fromMaybe)
 import Control.Monad (zipWithM)
 import Unsafe.Coerce (unsafeCoerce)
 
-simplify :: FExp -> Expr t e
-simplify = dedeBruE 0 [] 0 [] . transExpr 0 0 . revealF
+simplify :: FI.FExp -> Expr t e
+simplify = dedeBruE 0 [] 0 [] . transExpr 0 0 . FI.revealF
 
 simplify' :: FI.Expr t e -> Expr t e
 simplify' = dedeBruE 0 [] 0 [] . transExpr 0 0 . unsafeCoerce
-
-newtype FExp = HideF { revealF :: forall t e. FI.Expr t e }
 
 infer :: Index -> Index -> FI.Expr Index (Index, FI.Type Index) -> FI.Type Index
 infer i j (FI.Var _ (_, t))       = t


### PR DESCRIPTION
As we will soon have a new implementation of Simplify, this will make swapping and testing different implementations possible.
