### PR TITLE
[#78] Support string interpolation

### DIFF
--- a/examples/Point.sf
+++ b/examples/Point.sf
@@ -13,4 +13,4 @@ type Point = {
 let black  = { red = 0, green = 0, blue = 0 };
 let origin = { x = 0, y = 0, z = 0 };
 
-"The origin is at ({origin.x},{origin.y},{origin.z})"
+"The origin is at (\{origin.x},\{origin.y},\{origin.z})"


### PR DESCRIPTION
This patch changes the lexer a bit. It uses startcodes to distinguish the states of tokens, which are _in_ the string (`<str>`) or _not in_ the string (`<0>` and `<strexp>`). The lexer also breaks down the string to separate `Tschar` (namely _string characters_) tokens instead of a single `Tstring` token.

The parser later combines `Tschar` into a string literal and concatenate it with interpolated expressions surrounded by `\{` and `}`. The expression is stringified by the Java static method of string, namely `String .valueof()`, which is type-safe.

But I don't know if generating so many `Tschar` tokens will bring any side effects on the performance of lexer and parser. And this patch may perhaps introduce some bugs of parsing the string. Please help test and comment this patch. Thanks!
