### PR TITLE
Document & refine string interpolation

### DIFF
--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -34,6 +34,8 @@ Variable names start with lower case letters.
 
 Boolean literals: `True`, `False`
 
+String interpolation: `let t = 3; "\{t} times 2 is \{(\(x: Int) -> x * 2) t}"`
+
 Lambdas: `\(x: Int) (y: Int) -> x + y`
 
 Type lambdas: `/\A -> \(x: A) -> x`


### PR DESCRIPTION
- Refine the `jconcat` function in `Parser.y` to be more readable.
- Add entry for string interpolation in the cheat sheet.
