### PR TITLE
Use cabal-version: >= 1.10

### DIFF
--- a/fcore.cabal
+++ b/fcore.cabal
@@ -1,6 +1,6 @@
 name:                   fcore
 version:                0.1.0
-cabal-version:          >= 1.8
+cabal-version:          >= 1.10
 build-type:             Simple
 license:                BSD3
 license-file:           LICENSE


### PR DESCRIPTION
This is to silence the warning "To use the 'default-language' field the
package needs to specify at least 'cabal-version: >= 1.10'"
