### PR TITLE
doc for windows. ref #124

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,6 @@ Ubuntu. It builds the compiler from source, thus may take some time.
 
 2. Then the same as above.
 
-    If when you run program, meet a problem like this
-    ```java
-    java.lang.NullPointerException
-        at f2j.FileServer.compile(Unknown Source)
-        at f2j.FileServer.compileLoad(Unknown Source)
-        at f2j.FileServer.main(Unknown Source)
-    FileLoad.hs: fd:4: hGetLine: end of file
-    ```
-    This may be related to [ToolProvider.getSystemJavaCompiler returns null](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6477844).
-    As a workaround, modify the file `fcore\runtime\f2j\FileServer.java`
-    ```java
-    //replace 2nd argument by the real path, add this line
-    System.setProperty("java.home", "the path to your jdk directory, same as JAVA_HOME")
-    //before this line
-    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-    ```
-
 ## Documentation ##
 
 See `doc` directory for more details.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,31 @@ Ubuntu. It builds the compiler from source, thus may take some time.
 
 ## Building on Windows ##
 
-TODO
+1. Software preparation
+    - [Java SDK (8 or newer)](http://www.oracle.com/technetwork/java/index.html)
+    - [Apache Ant (version 1.8 or above)](http://ant.apache.org/)
+    - [git](http://git-scm.com/)
+    - [minGHC](https://github.com/fpco/minghc), which includes GHC, Cabal, MSYS
+    - Have a make. There is a make in minghc\msys\bin. Or one can use [GNU Make](http://www.gnu.org/software/make/)
+
+2. Then the same as above.
+
+    If when you run program, meet a problem like this
+    ```java
+    java.lang.NullPointerException
+        at f2j.FileServer.compile(Unknown Source)
+        at f2j.FileServer.compileLoad(Unknown Source)
+        at f2j.FileServer.main(Unknown Source)
+    FileLoad.hs: fd:4: hGetLine: end of file
+    ```
+    This may be related to [ToolProvider.getSystemJavaCompiler returns null](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6477844).
+    As a workaround, modify the file `fcore\runtime\f2j\FileServer.java`
+    ```java
+    //replace 2nd argument by the real path, add this line
+    System.setProperty("java.home", "the path to your jdk directory, same as JAVA_HOME")
+    //before this line
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    ```
 
 ## Documentation ##
 

--- a/fcore.cabal
+++ b/fcore.cabal
@@ -4,7 +4,7 @@ cabal-version:          >= 1.10
 build-type:             Simple
 license:                BSD3
 license-file:           LICENSE
-copyright:              (c) 2014—2015 The F2J Project Developers (given in AUTHORS.txt)
+copyright:              (c) 2014-2015 The F2J Project Developers (given in AUTHORS.txt)
 category:               Language
 stability:              experimental
 tested-with:            GHC == 7.8.3

--- a/lib/Parser.y
+++ b/lib/Parser.y
@@ -4,7 +4,7 @@
 {- |
 Module      :  Parser
 Description :  Parser for the source language.
-Copyright   :  (c) 2014—2015 The F2J Project Developers (given in AUTHORS.txt)
+Copyright   :  (c) 2014-2015 The F2J Project Developers (given in AUTHORS.txt)
 License     :  BSD3
 
 Maintainer  :  Zhiyuan Shi <zhiyuan.shi@gmail.com>, Weixin Zhang <zhangweixinxd@gmail.com>

--- a/runtime/src/f2j/FileServer.java
+++ b/runtime/src/f2j/FileServer.java
@@ -18,6 +18,19 @@ public class FileServer {
 
         // Compile source file.
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if(compiler == null){
+            boolean isWin = System.getProperty("os.name").toLowerCase().indexOf("windows") >= 0;
+            String javaHome = System.getenv("JAVA_HOME");
+            if(isWin && !javaHome.isEmpty()){
+                System.setProperty("java.home",javaHome);
+                compiler = ToolProvider.getSystemJavaCompiler();
+            }
+        }
+
+        if(compiler == null){
+            System.err.println("Error: Can not get system java compiler");
+            System.exit(1);
+        }
 
         DiagnosticCollector <JavaFileObject> diagnostics =
             new DiagnosticCollector<JavaFileObject>();

--- a/testsuite/whitespace_check.rb
+++ b/testsuite/whitespace_check.rb
@@ -13,7 +13,7 @@ test_failed = false
 Dir[*where].each do |path|
   next if path.match(excluding)
 
-  File.open(path, "r") do |f|
+  File.open(path, "r", :encoding =>'utf-8') do |f|
     f.each_line.with_index do |line, i|
       line.chomp!
       line_number = i + 1


### PR DESCRIPTION
The steps works well in a new test machine with
- Win7 ultimate, 32bit
- ghci 7.8.3
- cabal-install 1.20.0.1

Removed some non-utf8 parts, to make 'happy', Cabal and Ruby be happy working on Windows.
