### PR TITLE
Datatype: remove CaseCast, add more test cases

### DIFF
--- a/lib/BaseTransCFJava.hs
+++ b/lib/BaseTransCFJava.hs
@@ -393,6 +393,7 @@ trans self =
                                      -- CFInteger -> J.ClassRefType $ J.ClassType [(J.Ident "java.lang.Integer", [])]
                                      -- CFChar -> J.ClassRefType $ J.ClassType [(J.Ident "java.lang.Character", [])]
                                      -- CFCharacter -> J.ClassRefType $ J.ClassType [(J.Ident "java.lang.Character", [])]
+                                     Datatype x _ _ -> J.ClassRefType $ J.ClassType [(J.Ident x, [])]
                                      _ -> sorry "BaseTransCFJava.trans.JMethod: no idea how to do")
                              types
                    (classStatement,rhs) <- case c of
@@ -448,16 +449,6 @@ trans self =
                           foldl (\acc es' -> translateApply this False acc es')
                                 (return ([st1], var newVar, functiontype))
                                 (map (translateM this) es)
-              CaseCast expr (Constructor ctrname ty) ->
-                do  (stmts, oexpr, t) <- translateM this expr
-                    let (Datatype nam _ _) = last ty
-                    if length ty == 1
-                    then return (stmts, oexpr, t)
-                    else do varname <- getNewVarName this
-                            let classname = (nam ++ '.' : nam ++ ctrname)
-                                objtype =  classTy classname
-                                objdecl =  localVar objtype $ varDecl varname (cast objtype $ unwrap oexpr)
-                            return (stmts ++ [objdecl], var varname, JClass classname)
               Case scrut alts ->
                 do (scrutStmts, scrutExpr, _) <- translateM this scrut
                    (altsStmts, varName, typ) <- transAlts this scrutExpr alts

--- a/lib/ClosureF.hs
+++ b/lib/ClosureF.hs
@@ -73,7 +73,6 @@ data Expr t e =
    | Data S.RecFlag [DataBind t] (Expr t e)
    | Constr (Constructor t) [Expr t e]
    | Case (Expr t e) [Alt t e]
-   | CaseCast (Expr t e) (Constructor t)
 
 data DataBind t = DataBind S.ReaderId [S.ReaderId] ([t] -> [Constructor t])
 data Constructor t = Constructor {constrName :: S.ReaderId, constrParams :: [Type t]}
@@ -157,7 +156,6 @@ fexp2cexp (C.Constr ctr es) = Constr (fctr2cctr ctr) (map fexp2cexp es)
 fexp2cexp (C.Case e alts) = Case (fexp2cexp e) (map falt2calt alts)
   where falt2calt (C.ConstrAlt ctr e1) = ConstrAlt (fctr2cctr ctr) (fexp2cexp e1)
         falt2calt (C.Default e1)       = Default (fexp2cexp e1)
-fexp2cexp (C.CaseCast e ctr) = CaseCast (fexp2cexp e) (fctr2cctr ctr)
 fexp2cexp e                         = Lam "Fun" (groupLambda e)
 
 fctr2cctr :: C.Constructor t -> Constructor t
@@ -396,4 +394,3 @@ prettyExpr p (i,j) (Case e alts) =
                (text (constrName c) <+> arrow <+> (align $ prettyExpr p (i, j) e1 ))
           pretty_alt (Default e1) =
                (text "_" <+> arrow <+> (align $ prettyExpr p (i, j) e1 ))
-prettyExpr p (i,j) (CaseCast e (Constructor nam _ )) = parens $ (parens $ text nam) <> prettyExpr p (i,j) e

--- a/lib/Core.hs
+++ b/lib/Core.hs
@@ -104,7 +104,6 @@ data Expr t e
   | Data Src.RecFlag [DataBind t] (Expr t e)
   | Constr (Constructor t) [Expr t e]
   | Case (Expr t e) [Alt t e]
-  | CaseCast (Expr t e) (Constructor t)
 
 data DataBind t = DataBind Src.ReaderId [Src.ReaderId] ([t] -> [Constructor t])
 
@@ -154,7 +153,6 @@ mapVar g h (Constr (Constructor n ts) es) = Constr c' (map (mapVar g h) es)
 mapVar g h (Case e alts)             = Case (mapVar g h e) (map mapAlt alts)
     where mapAlt (ConstrAlt (Constructor n ts) e1) = ConstrAlt (Constructor n (map h ts)) (mapVar g h e1)
           mapAlt (Default e1) = Default (mapVar g h e1)
-mapVar g h (CaseCast e (Constructor n ts)) = CaseCast (mapVar g h e) (Constructor n (map h ts))
 mapVar g h (App f e)                 = App (mapVar g h f) (mapVar g h e)
 mapVar g h (TApp f t)                = TApp (mapVar g h f) (h t)
 mapVar g h (If p b1 b2)              = If (mapVar g h p) (mapVar g h b1) (mapVar g h b2)
@@ -359,7 +357,6 @@ prettyExpr' p (i,j) (Case e alts) =
                (text (constrName c) <+> arrow <+> (align $ prettyExpr' p (i, j) e1 ))
           pretty_alt (Default e1) =
                (text "_" <+> arrow <+> (align $ prettyExpr' p (i, j) e1 ))
-prettyExpr' p (i,j) (CaseCast e (Constructor nam _ )) = parens $ (parens $ text nam) <> prettyExpr' p (i,j) e
 
 javaInt :: Type t
 javaInt = JClass "java.lang.Integer"

--- a/lib/OptiUtils.hs
+++ b/lib/OptiUtils.hs
@@ -78,7 +78,6 @@ joinExpr (Constr ctr es) = Constr ctr (map joinExpr es)
 joinExpr (Case e alts) = Case (joinExpr e) (map joinAlt alts)
   where joinAlt (ConstrAlt ctr e1) = ConstrAlt ctr (joinExpr e1)
         joinAlt (Default e1) = Default (joinExpr e1)
-joinExpr (CaseCast e ctr) = CaseCast (joinExpr e) ctr
 joinExpr (Proj i e) = Proj i (joinExpr e)
 joinExpr (Fix n1 n2 f t1 t2) = Fix n1 n2 (\e1 e2 -> joinExpr (f (Var n1 e1) (Var n2 e2))) t1 t2
 joinExpr (Let n bind body) = Let n (joinExpr bind) (joinExpr . body . Var n)
@@ -122,7 +121,6 @@ mapExpr f e =
       Case e' alts -> Case (f e') (map mapAlt alts)
          where mapAlt (ConstrAlt ctr e1) = ConstrAlt ctr (f e1)
                mapAlt (Default e1) = Default (f e1)
-      CaseCast e' ctr -> CaseCast (f e') ctr
       Seq es -> Seq $ map f es
       _ -> sorry "Not implemented yet"
 
@@ -158,7 +156,6 @@ rewriteExpr f num env expr =
    Data recflag databinds e -> Data recflag databinds (f num env e)
    Constr c es -> Constr c (map (f num env) es)
    Case e alts -> Case (f num env e) (map rewriteAlt alts)
-   CaseCast e ctr -> CaseCast (f num env e) ctr
  where
    rewriteAlt (ConstrAlt ctr e) = ConstrAlt ctr (f num env e)
    rewriteAlt (Default e)       = Default (f num env e)

--- a/lib/Src.hs
+++ b/lib/Src.hs
@@ -157,7 +157,6 @@ data Expr id ty
   | ConstrTemp Name
   | Constr Constructor [LExpr id ty] -- post typecheck only
                                      -- the last type in Constructor will always be the real type
-  | CaseCast (LExpr id ty) Constructor
   | JProxyCall (LExpr id ty) ty
   deriving (Eq, Show)
 
@@ -477,7 +476,6 @@ instance (Show id, Pretty id, Show ty, Pretty ty) => Pretty (Expr id ty) where
     pretty e
 
   pretty (Case e alts) = hang 2 (text "case" <+> pretty e <+> text "of" <$> text " " <+> intersperseBar (map pretty alts))
-  pretty (CaseCast e (Constructor nam _ )) = parens $ (parens $ text nam) <> pretty e
   pretty (CaseString e alts) = hang 2 (text "case" <+> pretty e <+> text "of" <$> text " " <+> intersperseBar (map pretty alts))
   pretty (Constr c es) = parens $ hsep $ text (constrName c) : map pretty es
   pretty e = text (show e)

--- a/lib/SystemFI.hs
+++ b/lib/SystemFI.hs
@@ -110,7 +110,6 @@ data Expr t e
   | Data Src.RecFlag [DataBind t] (Expr t e)
   | Constr (Constructor t) [Expr t e]
   | Case (Expr t e) [Alt t e]
-  | CaseCast (Expr t e) (Constructor t)
 
 newtype FExp = HideF { revealF :: forall t e. Expr t e }
 
@@ -167,7 +166,6 @@ mapVar g h (Constr (Constructor n ts) es) = Constr c' (map (mapVar g h) es)
 mapVar g h (Case e alts)             = Case (mapVar g h e) (map mapAlt alts)
     where mapAlt (ConstrAlt (Constructor n ts) e1) = ConstrAlt (Constructor n (map h ts)) (mapVar g h e1)
           mapAlt (Default e1) = Default (mapVar g h e1)
-mapVar g h (CaseCast e (Constructor n ts))         = CaseCast (mapVar g h e) (Constructor n (map h ts))
 mapVar g h (App f e)                 = App (mapVar g h f) (mapVar g h e)
 mapVar g h (TApp f t)                = TApp (mapVar g h f) (h t)
 mapVar g h (If p b1 b2)              = If (mapVar g h p) (mapVar g h b1) (mapVar g h b2)
@@ -376,4 +374,3 @@ prettyExpr' p (i,j) (Case e alts) =
           pretty_alt (Default e1) =
                (text "_" <+> arrow <+> (align $ prettyExpr' p (i, j) e1 ))
 
-prettyExpr' p (i,j) (CaseCast e (Constructor nam _ )) = parens $ (parens $ text nam) <> prettyExpr' p (i,j) e

--- a/lib/simplify/SimplifyImpl.hs
+++ b/lib/simplify/SimplifyImpl.hs
@@ -78,7 +78,6 @@ infer i j (FI.Constr c _)         = last . FI.constrParams $ c
 infer i j (FI.Case _ alts)        = inferAlt . head $ alts
   where inferAlt (FI.ConstrAlt _ e) = infer i j e
         inferAlt (FI.Default e)       = infer i j e
-infer i j (FI.CaseCast _ (FI.Constructor _ ty)) = last ty
 infer i j (FI.Data _ _ e)         = infer i j e
 infer _ _ _                       = trace "Unsupported: Simplify.infer" FI.Unit
 
@@ -128,7 +127,6 @@ transExpr i j (FI.RecordProj e l1)         = App c $ transExpr i j e
 transExpr i j (FI.RecordUpdate e (l1, e1)) = App c $ transExpr i j e
   where Just (_, c) = putter i j (infer i j e) l1 (transExpr i j e1)
 transExpr i j (FI.Constr (FI.Constructor n ts) es) = Constr (Constructor n . map (transType i) $ ts) . map (transExpr i j) $ es
-transExpr i j (FI.CaseCast e (FI.Constructor n ts))= CaseCast (transExpr i j e) (Constructor n . map (transType i) $ ts)
 transExpr i j (FI.Case e alts)             = Case e' . map transAlt $ alts
   where
     e' = transExpr i j e
@@ -304,7 +302,6 @@ dedeBruE i as j xs (Case e alts)                  = Case (dedeBruE i as j xs e) 
   where dedeBruijnAlt (ConstrAlt (Constructor name ts) e1) =
           ConstrAlt (Constructor name (map (dedeBruT i as) ts)) (dedeBruE i as j xs e1)
         dedeBruijnAlt (Default e1) = Default (dedeBruE i as j xs e1)
-dedeBruE i as j xs (CaseCast e (Constructor name types)) = CaseCast (dedeBruE i as j xs e) (Constructor name (map (dedeBruT i as) types))
 
 dedeBruE i as j xs (Data recflag databinds e)     = Data recflag (map dedeBruijnDatabind databinds) (dedeBruE i as j xs e)
   where dedeBruijnConstr i' as' (Constructor name types) = Constructor name (map (dedeBruT i' as') types)

--- a/testsuite/tests/shouldRun/Forest.sf
+++ b/testsuite/tests/shouldRun/Forest.sf
@@ -1,0 +1,28 @@
+--> 4
+
+data rec
+  TreeT [A] = EmptyT | NodeT A (Forest [A])
+and
+  Forest [A] = NilF | ConsF (TreeT [A]) (Forest [A]);
+
+let rec
+  count_nil_tree [A] (x:TreeT[A]):Int =
+    case x of
+       EmptyT -> 0
+     | NodeT x xs -> count_nil_forest [A] xs
+and
+  count_nil_forest [A] (x:Forest[A]):Int =
+    case x of
+       NilF -> 1
+     | ConsF x y -> (count_nil_tree [A] x) + (count_nil_forest [A] y);
+
+let test = ConsF [Int]
+     (NodeT [Int] 1
+                 (ConsF [Int] (NodeT [Int] 2 (NilF [Int]))
+                              (NilF [Int])))
+     (ConsF [Int] (NodeT [Int] 3
+                               (NilF [Int]))
+                  (NilF [Int]));
+count_nil_forest [Int] test
+
+

--- a/testsuite/tests/shouldRun/NestedPattern.sf
+++ b/testsuite/tests/shouldRun/NestedPattern.sf
@@ -1,0 +1,17 @@
+--> 1
+
+data BTree [A,B] = Leaf A
+                 | Node BTree[A,B] B BTree[A,B]
+                 ;
+
+let children [A,B] (x:BTree [A,B]) =
+    case x of
+        Leaf _ -> -1
+      | Node (Leaf _) _ (Leaf _) -> 0
+      | Node _ _ (Leaf _) -> 1
+      | Node (Leaf _) _ _ -> 1
+      | Node _ _ _ -> 2
+;
+
+let tree = Node[Int,Int] (Leaf[Int,Int] 2) 1 (Node[Int,Int] (Leaf[Int,Int] 4) 3 (Leaf[Int,Int] 5));
+children [Int,Int] tree

--- a/testsuite/tests/shouldntTypecheck/NonexhaustivePattern.sf
+++ b/testsuite/tests/shouldntTypecheck/NonexhaustivePattern.sf
@@ -1,0 +1,13 @@
+data PolyList [A] = Nil
+                | Cons A (PolyList[A])
+                ;
+
+let rec removeDuplicates [A] (x:PolyList[A]): PolyList[A] =
+    case x of
+        Nil -> x
+      | Cons x (Cons y z) ->
+            if x == y then Cons [A] x (removeDuplicates [A] z)
+            else Cons [A] x (Cons [A] y (removeDuplicates [A] z))
+;
+
+removeDuplicates

--- a/testsuite/tests/shouldntTypecheck/OverlapPattern.sf
+++ b/testsuite/tests/shouldntTypecheck/OverlapPattern.sf
@@ -1,0 +1,14 @@
+data BTree [A,B] = Leaf A
+                 | Node BTree[A,B] B BTree[A,B]
+                 ;
+
+let children [A,B] (x:BTree [A,B]) =
+    case x of
+        Leaf _ -> -1
+      | Node (Leaf _) _ _ -> 1
+      | Node _ _ (Leaf _) -> 1
+      | Node (Leaf _) _ (Leaf _) -> 0
+      | Node _ _ _ -> 2
+;
+
+children


### PR DESCRIPTION
- CaseCast is unneeded and removed.
- Here are already some datatype test cases. Add tests for nested pattern, mutually recursive datatype, pattern exhaustivity test and pattern usefulness test.
