### PR TITLE
Inject prelude module into executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 
 install:
   - stack setup --no-terminal
-  - make
+  - make new
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ whitespace_test :
 
 .PHONY : runtime
 runtime :
-	cd runtime && ant && cd ..
+	cd runtime ; ant
 
 .PHONY : parsers
 parsers :
-	cd $(SRC_DIR) && make && cd ..
+	cd $(SRC_DIR) ; make
 
 # .PHONY : guard
 # guard :

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ FLAGS := -m naive
 
 all : compiler
 
+# Hack for first time install
+.PHONY : new
+new : compiler prelude
+	make compiler
+
+# for rebuild prelude module
+.PHONY : prelude
 prelude : prerequisite mkprelude runtime compiler
 
 .PHONY : prerequisite

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,14 @@ SF_FILES := $(wildcard $(PREDEF_DIR)/*.sf)
 FLAGS := -m naive
 
 
-all : prerequisite compiler mkprelude
+all : prerequisite compiler mkprelude compiler
 
 .PHONY : prerequisite
 prerequisite :
 	mkdir -p $(PRELUDE_DIR)
 	rm -f $(PRELUDE_DIR)/*.java
+	cd runtime; ant clean
+
 
 mkprelude : $(SF_FILES)
 	f2j $(FLAGS) $^

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ SF_FILES := $(wildcard $(PREDEF_DIR)/*.sf)
 FLAGS := -m naive
 
 
-all : prerequisite compiler mkprelude compiler
+all : compiler
+
+prelude : prerequisite mkprelude runtime compiler
 
 .PHONY : prerequisite
 prerequisite :
@@ -17,12 +19,11 @@ prerequisite :
 	rm -f $(PRELUDE_DIR)/*.java
 	cd runtime; ant clean
 
-
+.PHONY : mkprelude
 mkprelude : $(SF_FILES)
 	f2j $(FLAGS) $^
 	cp $(PREDEF_DIR)/*.java $(PRELUDE_DIR)
 	rm -f $(PREDEF_DIR)/*.java
-	make runtime
 
 .PHONY : compiler
 compiler : runtime

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Ubuntu. It builds the compiler from source, thus may take some time.
 3. Quick install with stack:
 
    ```bash
-   make runtime
-   stack install
+   make
    ```
 
    You may be prompted to run `stack setup`, which will automatically

--- a/fcore.cabal
+++ b/fcore.cabal
@@ -31,6 +31,7 @@ library
                       , network == 2.6.*
                       , parsec == 3.1.*
                       , pretty == 1.1.*
+                      , th-lift == 0.7.*
                       , process == 1.2.*
                       , split == 0.2.*
                       , template-haskell == 2.10.*

--- a/fcore.cabal
+++ b/fcore.cabal
@@ -88,9 +88,7 @@ executable f2j
   default-language:     Haskell2010
   hs-source-dirs:       compiler
   main-is:              Main.hs
-  build-depends:        fcore
-                      , ansi-wl-pprint == 0.6.*
-                      , optparse-applicative
+  build-depends:        ansi-wl-pprint == 0.6.*
                       , array == 0.5.*
                       , base == 4.*
                       , bytestring == 0.10.*
@@ -98,11 +96,13 @@ executable f2j
                       , cmdargs == 0.10.*
                       , containers == 0.5.*
                       , directory == 1.2.*
+                      , fcore
                       , filepath == 1.4.*
                       , haskeline == 0.7.*
                       , language-java == 0.2.*
                       , mtl == 2.2.*
                       , network == 2.6.*
+                      , optparse-applicative
                       , parsec == 3.1.*
                       , pretty == 1.1.*
                       , process == 1.2.*

--- a/lib/FrontEnd.hs
+++ b/lib/FrontEnd.hs
@@ -20,7 +20,7 @@ source2core optDump source
                        exitFailure
       POk parsed -> do
         when (optDump == Parsed) $ print (pretty parsed)
-        result <- typeCheck parsed False
+        result <- typeCheck parsed
         case result of
           Left typeError -> do print (pretty typeError)
                                exitFailure

--- a/lib/JavaUtils.hs
+++ b/lib/JavaUtils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 {- |
 Module      :  JavaUtils
@@ -15,18 +14,15 @@ module JavaUtils
   ( getRuntimeJarPath
   , getClassPath
   , compileJava, runJava
-  , inferOutputPath, inferClassName, predefList
+  , inferOutputPath, inferClassName
   , ClassName, MethodName, FieldName
   , ModuleName
   ) where
 
-import Data.List (isSuffixOf)
 import StringUtils (capitalize)
-import System.IO.Unsafe (unsafePerformIO)
 
-import Language.Haskell.TH.Syntax
 import Paths_fcore
-import System.Directory (setCurrentDirectory, getCurrentDirectory, getDirectoryContents)
+import System.Directory (setCurrentDirectory, getCurrentDirectory)
 import System.FilePath (takeDirectory, takeFileName, takeBaseName, (</>), (<.>), dropExtension, searchPathSeparator)
 import System.Process.Extra (system_)
 
@@ -69,12 +65,3 @@ runJava srcPath = do
     system_ $ "java -cp " ++ cp ++ " " ++ takeBaseName srcPath
     system_ "rm *.class"
     setCurrentDirectory currDir
-
--- Here we want to do "safe" compile-time computation to get the list
--- of pre-defined functions
-getPredef :: [(Maybe String, String)]
-getPredef =
-  let filePaths = unsafePerformIO $ getDirectoryContents "lib/predef"
-  in ((map (\path -> (Just "f2j.prelude", takeBaseName path)) (filter (isSuffixOf "sf") filePaths)))
-
-predefList = [| $(lift getPredef) |]

--- a/lib/Loop.hs
+++ b/lib/Loop.hs
@@ -386,7 +386,7 @@ src2fi fname = do
      string <- readFile (path ++ "/" ++ fname)
      case reader string of
        POk expr -> do
-         result <- typeCheck expr False
+         result <- typeCheck expr
          case result of
            Left typeError -> error $ show typeError
            Right (_, tcheckedSrc) ->

--- a/lib/Predef.hs
+++ b/lib/Predef.hs
@@ -1,15 +1,27 @@
 {-# LANGUAGE TemplateHaskell #-}
-module Predef (processPredef) where
+module Predef (getPredefInfoTH) where
 
+import System.IO.Unsafe (unsafePerformIO)
+import System.Directory
+import System.FilePath
 
 import JvmTypeQuery
+import RuntimeProcessManager
 import StringUtils
-import JavaUtils
+import Data.List
+import Src
+import Language.Haskell.TH.Syntax (lift)
 
+-- Here I am doing crazy things ...
 
-processPredef h = do
-  let lists = $(predefList)
-  res <- fmap sequence (mapM (\info -> getModuleInfo h info True) lists)
+-- grab all the information of prelude modules, and inject it to
+-- the compiler itself
+getPredef h = do
+  filePaths <- getDirectoryContents "lib/predef"
+  let lists = ((map (\path -> (Just "f2j.prelude", takeBaseName path))
+                 (filter (isSuffixOf "sf") filePaths)))
+  -- return lists
+  res <- fmap sequence (mapM (\info -> getModuleInfo h info) lists)
   let info =
         case res of
           Nothing  -> [] -- we cannot panic here, as this will leave the Java process hanging around
@@ -18,3 +30,8 @@ processPredef h = do
 
   where
     flatInfo (p, mname) = map (\(ModuleInfo f g t) -> (f, (Just "f2j.prelude", t, g, capitalize mname))) p
+
+getPredefInfo :: [(String, ModuleMapInfo)]
+getPredefInfo = unsafePerformIO $ withTypeServer getPredef True
+
+getPredefInfoTH = [| $(lift (getPredefInfo)) |]

--- a/lib/Predef.hs
+++ b/lib/Predef.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fforce-recomp #-}
+
 module Predef (getPredefInfoTH) where
 
 import System.IO.Unsafe (unsafePerformIO)

--- a/lib/Predef.hs
+++ b/lib/Predef.hs
@@ -2,7 +2,6 @@
 module Predef (processPredef) where
 
 
-import Panic
 import JvmTypeQuery
 import StringUtils
 import JavaUtils
@@ -13,7 +12,7 @@ processPredef h = do
   res <- fmap sequence (mapM (\info -> getModuleInfo h info True) lists)
   let info =
         case res of
-          Nothing  -> panic "Failed to load prelude"
+          Nothing  -> [] -- we cannot panic here, as this will leave the Java process hanging around
           Just ret -> (concatMap flatInfo ret)
   return info
 

--- a/lib/Src.hs
+++ b/lib/Src.hs
@@ -9,7 +9,7 @@ Portability :  portable
 -}
 
 
-{-# LANGUAGE DeriveDataTypeable, RecordWildCards #-}
+{-# LANGUAGE DeriveDataTypeable, RecordWildCards, TemplateHaskell #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
@@ -48,25 +48,22 @@ module Src
   , defaultMatrix
   ) where
 
-import Config
-import JavaUtils
-import PrettyUtils
-import Panic
-import SrcLoc
+import           Config
+import           JavaUtils
+import           Panic
+import           PrettyUtils
+import           SrcLoc
 
-import qualified Language.Java.Syntax as J (Op(..))
--- import qualified Language.Java.Pretty as P
-import Text.PrettyPrint.ANSI.Leijen
-
-import Control.Arrow (second)
-
-import Data.Maybe (fromJust)
-import Data.Data
-import Data.List (intersperse, findIndex, nub)
+import           Control.Arrow (second)
+import           Data.Data
+import           Data.List (intersperse, findIndex, nub)
 import qualified Data.Map as Map
+import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
-
-import Prelude hiding ((<$>))
+import           Language.Haskell.TH.Lift
+import qualified Language.Java.Syntax as J (Op(..))
+import           Prelude hiding ((<$>))
+import           Text.PrettyPrint.ANSI.Leijen
 
 -- Names and identifiers.
 type Name      = String
@@ -612,3 +609,7 @@ specializedMatrix ctr pats =
 defaultMatrix :: [[Pattern]] -> [[Pattern]]
 defaultMatrix pats =
     [tail list1 | list1 <- pats, isWildcardOrVar . head $ list1]
+
+-- Make some instances of TH
+$(deriveLift ''Type)
+$(deriveLift ''JVMType)

--- a/lib/predef/Number.sf
+++ b/lib/predef/Number.sf
@@ -9,6 +9,8 @@ rec rem (n : Int) (m : Int) : Int = if n < m then n else rem (n - m) m;
 rec even (n : Int) : Bool = if n == 0 then True  else odd  (n - 1)
 and odd  (n : Int) : Bool = if n == 0 then False else even (n - 1);
 
+rec fact (n:Int) : Int = if n == 0 then 1 else n * fact (n-1);
+
 rec gcd (n : Int) (m : Int) : Int =
   let n' = abs n and
       m' = abs m;

--- a/lib/typeCheck/TypeCheck.hs
+++ b/lib/typeCheck/TypeCheck.hs
@@ -36,12 +36,12 @@ import IOEnv
 import JavaUtils
 import JvmTypeQuery
 import Panic
+import Predef
 import PrettyUtils
 import RuntimeProcessManager (withRuntimeProcess)
 import Src
 import SrcLoc
 import StringUtils
-import Predef
 
 import Control.Monad.Except
 import Data.List (findIndex, intercalate)

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -23,7 +23,7 @@ main = do
         do liftIO printHelp
            runInputT defaultSettings
                          (Loop.loop (inP, outP) (0, compileN, [Naive])
-                          Map.empty Env.empty Hist.empty Hist.empty 0 False False False False 0))
+                          Map.empty Env.empty Hist.empty Hist.empty 0 False False False False 0)) False
 
 fileExist :: String -> IO ()
 fileExist name = do

--- a/testsuite/TypeCheckSpec.hs
+++ b/testsuite/TypeCheckSpec.hs
@@ -20,4 +20,4 @@ tcSpec =
     forM_ failingCases
       (\(name, source) -> it ("should reject " ++ name) $
          let POk parsed = reader source
-         in typeCheck parsed True >>= ((`shouldSatisfy` hasError)))
+         in typeCheck parsed >>= ((`shouldSatisfy` hasError)))

--- a/testsuite/tests/shouldRun/PreludeTest.sf
+++ b/testsuite/tests/shouldRun/PreludeTest.sf
@@ -1,0 +1,4 @@
+--> true
+
+-- Test if prelude module is loaded
+even (gcd (fact (2 ^ (id [Int] 2))) (rem 4 2))


### PR DESCRIPTION
This speeds up type checking as the type checker doesn't need to consult
the runtime jar every time it uses prelude module. However, to get the
information right, we need to do a little bit more if anything changes
in the prelude module. Below is the scenario:
1. Someone modifies the prelude module
2. To let the compiler know the changes, we first recompile the prelude
   module using the old compiler, and get some Java files
3. Then we rebuild the runtime jar with the newly generated Java files
4. Finally we rebuild the compiler. During building, GHC grabs the
   information from the new runtime jar, and injects the prelude module
   into the executable
