### PR TITLE
Drop `lens` dependency

### DIFF
--- a/fcore.cabal
+++ b/fcore.cabal
@@ -27,7 +27,7 @@ library
                       , filepath == 1.4.*
                       , haskeline == 0.7.*
                       , language-java == 0.2.*
-                      , lens == 4.12.*
+                      , microlens == 0.2.0.*
                       , mtl == 2.2.*
                       , network == 2.6.*
                       , parsec == 3.1.*

--- a/lib/BaseTransCFJava.hs
+++ b/lib/BaseTransCFJava.hs
@@ -19,9 +19,9 @@ module BaseTransCFJava where
 -- TODO: isolate all hardcoded strings to StringPrefixes (e.g. Fun)
 
 
-import           Control.Lens
 import           Data.Char (toLower)
 import           Data.List (zip4, elemIndex)
+import           Lens.Micro
 
 import           ClosureF
 import           Inheritance


### PR DESCRIPTION
`lens` pulls way too many dependencies to the project. Besides, we don't
need those fancy "batteries" `lens` has to offer. Use `microlens` is
enough for us.
